### PR TITLE
Add test for rounding up 12 with multiplier of 4

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,70 +13,77 @@ use traits::Multiplier;
 
 /// Rounds the number down.
 #[inline(always)]
-pub fn down<M: Multiplier>(value: M::Number, multiplier: M) -> M::Number { multiplier.down(value) }
+pub fn down<M: Multiplier>(value: M::Number, multiplier: M) -> M::Number {
+    multiplier.down(value)
+}
 
 /// Rounds the number up.
 ///
 /// Returns [`None`] if the result overflows.
 #[inline(always)]
 pub fn up<M: Multiplier>(value: M::Number, multiplier: M) -> Option<M::Number> {
-	multiplier.up(value)
+    multiplier.up(value)
 }
 
 #[cfg(test)]
 mod test {
-	use core::num::NonZeroU8;
+    use core::num::NonZeroU8;
 
-	use quickcheck::TestResult;
-	use quickcheck_macros::quickcheck;
+    use quickcheck::TestResult;
+    use quickcheck_macros::quickcheck;
 
-	use super::*;
+    use super::*;
 
-	#[quickcheck]
-	fn mult2_down_round_mult_is_identity(value: NonZeroPow2<u8>) -> bool {
-		down(value.get(), value) == value.get()
-	}
+    #[quickcheck]
+    fn mult2_down_round_mult_is_identity(value: NonZeroPow2<u8>) -> bool {
+        down(value.get(), value) == value.get()
+    }
 
-	#[quickcheck]
-	fn mult2_up_round_mult_is_identity(value: NonZeroPow2<u8>) -> bool {
-		up(value.get(), value) == Some(value.get())
-	}
+    #[quickcheck]
+    fn mult2_up_round_mult_is_identity(value: NonZeroPow2<u8>) -> bool {
+        up(value.get(), value) == Some(value.get())
+    }
 
-	#[quickcheck]
-	fn mult_down_round_mult_is_identity(value: NonZeroU8) -> bool {
-		down(value.get(), value) == value.get()
-	}
+    #[quickcheck]
+    fn mult_down_round_mult_is_identity(value: NonZeroU8) -> bool {
+        down(value.get(), value) == value.get()
+    }
 
-	#[quickcheck]
-	fn mult_up_round_mult_is_identity(value: NonZeroU8) -> bool {
-		up(value.get(), value) == Some(value.get())
-	}
+    #[quickcheck]
+    fn mult_up_round_mult_is_identity(value: NonZeroU8) -> bool {
+        up(value.get(), value) == Some(value.get())
+    }
 
-	#[quickcheck]
-	fn mult_up_overflow_is_none(value: u8, mult: NonZeroU8) -> TestResult {
-		if value % mult.get() != 0 && u8::MAX - ((value / mult) * mult.get()) < mult.get() {
-			TestResult::from_bool(up(value, mult).is_none())
-		} else {
-			TestResult::discard()
-		}
-	}
+    #[quickcheck]
+    fn mult_up_overflow_is_none(value: u8, mult: NonZeroU8) -> TestResult {
+        if value % mult.get() != 0 && u8::MAX - ((value / mult) * mult.get()) < mult.get() {
+            TestResult::from_bool(up(value, mult).is_none())
+        } else {
+            TestResult::discard()
+        }
+    }
 
-	#[quickcheck]
-	fn mult2_up_overflow_is_none(value: u8, mult: NonZeroPow2<u8>) -> TestResult {
-		if value % mult.get() != 0 && u8::MAX - ((value / mult.get()) * mult.get()) < mult.get() {
-			TestResult::from_bool(up(value, mult).is_none())
-		} else {
-			TestResult::discard()
-		}
-	}
+    #[quickcheck]
+    fn mult2_up_overflow_is_none(value: u8, mult: NonZeroPow2<u8>) -> TestResult {
+        if value % mult.get() != 0 && u8::MAX - ((value / mult.get()) * mult.get()) < mult.get() {
+            TestResult::from_bool(up(value, mult).is_none())
+        } else {
+            TestResult::discard()
+        }
+    }
 
-	#[quickcheck]
-	fn mult2_down_is_correct(value: u8, mult: NonZeroPow2<u8>) -> bool {
-		down(value, mult) == (value / mult.get()) * mult.get()
-	}
+    #[quickcheck]
+    fn mult2_down_is_correct(value: u8, mult: NonZeroPow2<u8>) -> bool {
+        down(value, mult) == (value / mult.get()) * mult.get()
+    }
 
-	#[quickcheck]
-	fn mult_down_is_correct(value: u8, mult: NonZeroU8) -> bool {
-		down(value, mult) == (value / mult.get()) * mult.get()
-	}
+    #[quickcheck]
+    fn mult_down_is_correct(value: u8, mult: NonZeroU8) -> bool {
+        down(value, mult) == (value / mult.get()) * mult.get()
+    }
+
+    #[test]
+    fn up_pow_2_no_change() {
+        assert_eq!(up(12_usize, NonZeroPow2::new(4).unwrap()).unwrap(), 12);
+    }
 }


### PR DESCRIPTION
Adds a test which fails (because bug). I assume that rounding 12 up with a multiplier of 4 should result in 12. Btw I ran into this bug when rounding up 2199552 with a multiplier of 4, and the result was 2199556.